### PR TITLE
Feature/langchain impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://huggingface.co/spaces/chinkanai/wizledger
 
 ## Technologies
 
+-   LangChain
 -   LangGraph
 -   Google Cloud Vision API [Google Cloud Vision API](https://cloud.google.com/vision)
 -   OpenRouter API (for access Claude 3.5 Sonnet) [OpenRouter API](https://openrouter.ai/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 google-cloud-vision
 pdf2image
+langchain-openai
 langgraph
 requests
 gradio

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ import os
 import json
 import traceback
 from typing import List, Dict, Callable
-from langgraph.graph import StateGraph, END
+from langgraph.graph import StateGraph
 from langgraph.checkpoint.memory import MemorySaver
 from nodes.ocr_node import ocr_node
 from nodes.extract_node import extract_node
@@ -30,7 +30,7 @@ workflow.add_edge("extract", "display_transactions")
 workflow.add_edge("display_transactions", "get_human_input")
 workflow.add_edge("get_human_input", "process_human_input")
 workflow.add_edge("process_human_input", "check_if_done")
-workflow.add_edge("store_csv", END)
+workflow.set_finish_point("store_csv")
 
 # Add conditional edge
 workflow.add_conditional_edges(

--- a/src/models/transactions.py
+++ b/src/models/transactions.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field, RootModel
+from typing import List
+
+class Transaction(BaseModel):
+    date: str = Field(description="The date of the transaction in the format YYYY-MM-DD")
+    description: str = Field(description="A brief description of the transaction")
+    amount: float = Field(description="The transaction amount as a float (negative for debits, positive for credits)")
+
+class Transactions(RootModel[List[Transaction]]):
+    pass

--- a/src/utils/human_input_utils.py
+++ b/src/utils/human_input_utils.py
@@ -2,83 +2,55 @@ import requests
 import json
 import os
 from typing import List, Dict
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import PydanticOutputParser
+from models.transactions import Transactions
 
-def extract_json_from_string(s: str) -> str:
-    """Extract JSON object from a string."""
-    json_start = s.find('{')
-    json_end = s.rfind('}') + 1
-    if json_start != -1 and json_end != -1:
-        return s[json_start:json_end]
-    return ""
+def get_prompt_template() -> str:
+    return """Given the following list of transactions:
 
-def interpret_and_update(user_input: str, transactions: List[Dict[str, str]]) -> List[Dict[str, str]]:
-    prompt = f"""Given the following list of transactions:
-
-{json.dumps(transactions, indent=2)}
+{transactions}
 
 And the user's input:
 
 "{user_input}"
 
 Please interpret the user's intention and provide the updated list of transactions. 
-If the user wants to modify a specific transaction, update only that transaction.
-If the user wants to add a new transaction, add it to the list.
-If the user wants to delete a transaction, remove it from the list.
+- If the user wants to modify a specific transaction, update only that transaction.
+- If the user wants to add a new transaction, add it to the list.
+- If the user wants to delete a transaction, remove it from the list.
 
-Provide ONLY the updated list of transactions in the following JSON format without any additional text:
-{{
-    "transactions": [
-        {{"date": "DD MMM YYYY", "description": "Transaction description", "amount": "Amount in decimal format"}}
-    ]
-}}"""
+Each transaction should have the following properties:
+    - date: The date of the transaction in the format YYYY-MM-DD
+    - description: A brief description of the transaction
+    - amount: The transaction amount as a float (negative for debits, positive for credits)
 
-    headers = {
-        "Authorization": f"Bearer {os.getenv('OPENROUTER_API_KEY')}",
-        "Content-Type": "application/json"
-    }
+Provide ONLY the updated list of transactions in the JSON format.
+Please return ONLY the list of JSON objects, without any additional explanation or text."""
 
-    data = {
-        "model": os.getenv('OPENROUTER_MODEL'),
-        "messages": [{"role": "user", "content": prompt}]
-    }
+def interpret_and_update(user_input: str, transactions: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    
+    llm = ChatOpenAI(
+        model_name=os.getenv('OPENROUTER_MODEL'), 
+        openai_api_base=os.getenv('OPENROUTER_API_URL'), 
+        openai_api_key=os.getenv('OPENROUTER_API_KEY'))
+    
+    prompt_text = get_prompt_template()
+    prompt = ChatPromptTemplate.from_template(prompt_text)
+    parser = PydanticOutputParser(pydantic_object=Transactions)
+
+    chain = prompt | llm | parser
 
     try:
-        response = requests.post(os.getenv('OPENROUTER_API_URL'), headers=headers, json=data)
-        response.raise_for_status()
-        
-        result = response.json()
-        updated_transactions_str = result['choices'][0]['message']['content']
-        
-        print("AI Response:")
-        print(updated_transactions_str)
-        
-        # Extract JSON from the response
-        json_str = extract_json_from_string(updated_transactions_str)
-        
-        if not json_str:
-            print("Error: No valid JSON found in the AI response.")
-            return transactions
-        
-        try:
-            updated_data = json.loads(json_str)
-            if 'transactions' in updated_data and isinstance(updated_data['transactions'], list):
-                return updated_data['transactions']
-            else:
-                print("Error: AI response does not contain a 'transactions' list.")
-                return transactions
-        except json.JSONDecodeError as e:
-            print(f"Error parsing JSON from AI response: {str(e)}")
-            print("Extracted JSON content:")
-            print(json_str)
-            return transactions
-    except requests.RequestException as e:
-        print(f"Error making request to OpenRouter API: {str(e)}")
-        return transactions
-    except KeyError as e:
-        print(f"Error accessing API response data: {str(e)}")
-        print("API response content:")
-        print(json.dumps(result, indent=2))
-        return transactions
+        updated_transactions: Transactions = chain.invoke({"transactions": transactions, "user_input": user_input})
+        return updated_transactions.model_dump()
     except Exception as e:
         print(f"Unexpected error in interpret_and_update: {str(e)}")
         return transactions
+    
+if __name__ == "__main__":
+    with open("output/transactions.json", "r", encoding="utf-8") as jsonfile:
+        transactions = json.load(jsonfile)
+        updated_transactions = interpret_and_update("Add a new transaction on 2024-08-11 for 100.00, description is 'test'", transactions)
+        print(updated_transactions)

--- a/src/utils/transaction_utils.py
+++ b/src/utils/transaction_utils.py
@@ -3,47 +3,60 @@ import json
 import csv
 import os
 from typing import List, Dict
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import PydanticOutputParser
+from pydantic import BaseModel, Field, RootModel
 
-def extract_transactions(ocr_text: str) -> List[Dict[str, str]]:
-    prompt = f"""You are an AI assistant trained to extract transaction information from financial statements. 
+class Transaction(BaseModel):
+    date: str = Field(description="The date of the transaction in the format YYYY-MM-DD")
+    description: str = Field(description="A brief description of the transaction")
+    amount: float = Field(description="The transaction amount as a float (negative for debits, positive for credits)")
+
+class Transactions(RootModel[List[Transaction]]):
+    pass
+
+def get_prompt_template() -> str:
+    return """You are an AI assistant trained to extract transaction information from financial statements. 
     Given the following text from a financial statement, please extract all transactions and format them as a list of JSON objects.
     Each transaction should have the following properties:
     - date: The date of the transaction in the format YYYY-MM-DD
     - description: A brief description of the transaction
     - amount: The transaction amount as a float (negative for debits, positive for credits)
-
+    
     Here's the text from the financial statement:
 
     {ocr_text}
-
+    
     Please return ONLY the list of JSON objects, without any additional explanation or text."""
 
-    headers = {
-        "Authorization": f"Bearer {os.getenv('OPENROUTER_API_KEY')}",
-        "Content-Type": "application/json"
-    }
+def extract_transactions(ocr_text: str) -> List[Dict[str, str]]:
+    prompt_text = get_prompt_template()
 
-    data = {
-        "model": os.getenv('OPENROUTER_MODEL'),
-        "messages": [{"role": "user", "content": prompt}]
-    }
+    llm = ChatOpenAI(
+        model_name=os.getenv('OPENROUTER_MODEL'), 
+        openai_api_base=os.getenv('OPENROUTER_API_URL'), 
+        openai_api_key=os.getenv('OPENROUTER_API_KEY'))
+    prompt = ChatPromptTemplate.from_template(prompt_text)
+    parser = PydanticOutputParser(pydantic_object=Transactions)
+
+    #*** OpenRouter not support structured output ***  
+    # structured_llm = llm.with_structured_output(Transaction)
+    # chain = prompt | structured_llm
+
+    chain = prompt | llm | parser
 
     try:
-        response = requests.post(os.getenv('OPENROUTER_API_URL'), headers=headers, json=data)
-        response.raise_for_status()
-        
-        result = response.json()
-        transactions_str = result['choices'][0]['message']['content']
-        
-        transactions = json.loads(transactions_str)
-        
-        # Validate and clean up the transactions
+        transactions = chain.invoke({"ocr_text": ocr_text})
+
+        # validate and clean up the transactions
         validated_transactions = []
-        for transaction in transactions:
-            if all(key in transaction for key in ['date', 'description', 'amount']):
-                # Ensure amount is a float
-                transaction['amount'] = float(transaction['amount'])
-                validated_transactions.append(transaction)
+        for transaction in transactions.root:
+            # because Transaction is a BaseModel, so we can access the properties directly
+            if transaction.date and transaction.description and transaction.amount is not None:
+                # ensure amount is a float
+                transaction.amount = float(transaction.amount)
+                validated_transactions.append(transaction.model_dump())
         
         return validated_transactions
     except Exception as e:
@@ -60,3 +73,17 @@ def store_transactions_csv(transactions: List[Dict[str, str]], filename: str):
             writer.writerow(transaction)
     
     print(f"Transactions stored in {filename}")
+
+if __name__ == "__main__":
+
+    # load_dotenv()
+
+    print(os.getenv('OPENROUTER_API_KEY'))
+    print(os.getenv('OPENROUTER_API_URL'))
+    print(os.getenv('OPENROUTER_MODEL'))
+
+    # Read the sample text file
+    with open("output/sample1.txt", "r", encoding="utf-8") as file:
+        ocr_text = file.read()
+        transactions = extract_transactions(ocr_text)
+        print(transactions)


### PR DESCRIPTION
refactor: migrate transaction extraction to use LangChain
- Replace direct OpenRouter API calls with LangChain's ChatOpenAI
- Add Pydantic models for better type safety and validation
- Implement structured output parsing using LangChain's PydanticOutputParser
- Add Transaction and Transactions models for data validation
- Move prompt template to separate function
- Add test code in __main__ block
- Clean up code structure and improve error handling